### PR TITLE
Confirm and lock in public projects endpoints

### DIFF
--- a/__tests__/project.public.test.ts
+++ b/__tests__/project.public.test.ts
@@ -1,0 +1,94 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import projectRoutes from '../src/routes/project.routes';
+import Project from '../src/models/project.model';
+
+// Only Project is module-mocked; User is left real because
+// project.model.ts calls `Project.belongsTo(User, ...)` at import time,
+// which requires User to be an actual Sequelize Model subclass.
+jest.mock('../src/models/project.model');
+
+const PROJECT_ID = 'c3333333-3333-4333-8333-333333333333';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/projects', projectRoutes);
+  return app;
+}
+
+function mockProjectRow(overrides: Partial<Record<string, unknown>> = {}) {
+  const fields = {
+    id: PROJECT_ID,
+    userId: 'd4444444-4444-4444-8444-444444444444',
+    title: 'Campus Ride Share',
+    description: 'A carpooling app for students.',
+    owner: 'Jane Doe',
+    ownerRole: 'Backend Developer',
+    ownerAvatar: 'https://example.com/jane.jpg',
+    image: 'https://images.pexels.com/photos/3861969/pexels-photo-3861969.jpeg?auto=compress&cs=tinysrgb&w=600',
+    link: 'https://github.com/jane/rideshare',
+    demo: 'https://rideshare.example.com',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    ...overrides,
+  };
+  return { ...fields, toJSON: () => fields };
+}
+
+describe('GET /api/projects (public list)', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns 200 without an Authorization header', async () => {
+    (Project.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] });
+
+    const res = await request(buildApp()).get('/api/projects');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('includes owner display info but never an owner email', async () => {
+    (Project.findAndCountAll as jest.Mock).mockResolvedValue({
+      count: 1,
+      rows: [mockProjectRow()],
+    });
+
+    const res = await request(buildApp()).get('/api/projects');
+
+    expect(res.status).toBe(200);
+    const [project] = res.body.data.projects;
+    expect(project).toMatchObject({
+      owner: 'Jane Doe',
+      ownerRole: 'Backend Developer',
+      ownerAvatar: 'https://example.com/jane.jpg',
+    });
+    const body = JSON.stringify(res.body).toLowerCase();
+    expect(body).not.toContain('email');
+  });
+});
+
+describe('GET /api/projects/project/:id (public detail)', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns the project with owner info and no email', async () => {
+    (Project.findByPk as jest.Mock).mockResolvedValue(mockProjectRow());
+
+    const res = await request(buildApp()).get(`/api/projects/project/${PROJECT_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.project).toMatchObject({
+      owner: 'Jane Doe',
+      ownerRole: 'Backend Developer',
+    });
+    const body = JSON.stringify(res.body).toLowerCase();
+    expect(body).not.toContain('email');
+  });
+
+  it('returns 404 for a non-existent project id', async () => {
+    (Project.findByPk as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(buildApp()).get(`/api/projects/project/${PROJECT_ID}`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/swagger.config.ts
+++ b/src/swagger.config.ts
@@ -3129,7 +3129,7 @@ delete: {
 '/api/projects': {
   get: {
     summary: 'Get all projects',
-    description: 'Public endpoint - Retrieves all projects with pagination',
+    description: 'Public endpoint - Retrieves all projects with pagination, including owner display info (name/role/avatar). Never returns owner email.',
     tags: ['Projects'],
     security: [],
     parameters: [
@@ -3273,7 +3273,7 @@ delete: {
 '/api/projects/project/{id}': {
   get: {
     summary: 'Get project by ID',
-    description: 'Public endpoint - Retrieves project information by ID',
+    description: 'Public endpoint - Retrieves project information by ID, including owner display info (name/role/avatar). Never returns owner email.',
     tags: ['Projects'],
     security: [],
     parameters: [
@@ -3316,7 +3316,7 @@ delete: {
 '/api/projects/{id}': {
   patch: {
     summary: 'Update a project',
-    description: 'Partially updates a project. Only provided fields will be updated. Any authenticated user can update any project.',
+    description: 'Partially updates a project. Only provided fields will be updated. Only the project owner or an Admin may update it.',
     tags: ['Projects'],
     security: [
       {
@@ -3406,6 +3406,16 @@ delete: {
           }
         }
       },
+      403: {
+        description: 'Forbidden - not the project owner or an Admin',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Error'
+            }
+          }
+        }
+      },
       404: {
         description: 'Project not found',
         content: {
@@ -3420,7 +3430,7 @@ delete: {
   },
   delete: {
     summary: 'Delete a project',
-    description: 'Deletes a project. Any authenticated user can delete any project.',
+    description: 'Deletes a project. Only the project owner or an Admin may delete it.',
     tags: ['Projects'],
     security: [
       {
@@ -3462,6 +3472,16 @@ delete: {
       },
       401: {
         description: 'Unauthorized',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Error'
+            }
+          }
+        }
+      },
+      403: {
+        description: 'Forbidden - not the project owner or an Admin',
         content: {
           'application/json': {
             schema: {


### PR DESCRIPTION
Investigated GET /api/projects and GET /api/projects/project/:id and found they are already unauthenticated and already safe: neither handler uses a Sequelize `include`, so no User/email join can leak through the owner display fields (owner/ownerRole/ownerAvatar are plain denormalized strings on the Project row). No route or controller changes were needed for public access.

Add regression tests asserting both endpoints return 200 with no Authorization header, return owner display info, and never include an owner email in the payload - to lock this in against future changes (e.g. someone later adding an `include: User` for other reasons).

Also correct two stale Swagger descriptions left over from the prior authorization fix ("Any authenticated user can update/delete any project") and add the missing 403 response docs for PATCH/DELETE /api/projects/:id, plus note in the GET docs that owner email is never returned.