### PR TITLE
Add public members list and detail endpoints

### DIFF
--- a/__tests__/member.public.test.ts
+++ b/__tests__/member.public.test.ts
@@ -1,0 +1,159 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import memberRoutes from '../src/routes/member.route';
+import Member from '../src/models/member.model';
+import User from '../src/models/user.model';
+
+// Only Member is module-mocked. User is left as the real Sequelize Model
+// subclass (its static methods are stubbed per-test with jest.spyOn) because
+// member.model.ts calls `Member.belongsTo(User, ...)` at import time, which
+// requires User to be an actual Model subclass, not an automock.
+jest.mock('../src/models/member.model');
+jest.mock('../src/utils/cloudinary.utils', () => ({
+  uploader: { upload: jest.fn(), destroy: jest.fn() },
+}));
+
+const MEMBER_ID = 'a1111111-1111-4111-8111-111111111111';
+const USER_ID = 'b2222222-2222-4222-8222-222222222222';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/members', memberRoutes);
+  return app;
+}
+
+function baseMemberFields() {
+  return {
+    id: MEMBER_ID,
+    userId: USER_ID,
+    name: 'Jane Doe',
+    role: 'Backend Developer',
+    imageUrl: 'https://example.com/jane.jpg',
+    bio: 'Loves distributed systems.',
+    education: {
+      degree: 'BSc Computer Science',
+      institution: 'KIST',
+      description: 'Focused on distributed systems.',
+      imageUrl: 'https://example.com/edu.jpg',
+    },
+    contacts: { linkedin: 'https://linkedin.com/in/janedoe', github: 'https://github.com/janedoe' },
+    skillDetails: [{ name: 'Backend', technologies: ['Node.js', 'Postgres'], percent: 80 }],
+    skills: ['Node.js', 'Postgres'],
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+  };
+}
+
+// Simulates real Sequelize behavior: the joined User row (with email) is only
+// present on the returned instance when the caller actually requests the include.
+function mockMemberRow(includeUser: boolean) {
+  const fields: Record<string, unknown> = baseMemberFields();
+  if (includeUser) {
+    fields.User = { email: 'jane.doe@example.com' };
+  }
+  return { ...fields, toJSON: () => fields };
+}
+
+describe('GET /api/members (public list)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('returns 200 without an Authorization header', async () => {
+    jest.spyOn(User, 'findAndCountAll').mockResolvedValue({ count: 0, rows: [] } as never);
+
+    const res = await request(buildApp()).get('/api/members');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('never includes email, phone, or whatsapp in the payload', async () => {
+    jest.spyOn(User, 'findAndCountAll').mockResolvedValue({
+      count: 1,
+      rows: [{ id: USER_ID, firstName: 'Jane', lastName: 'Doe' }],
+    } as never);
+    (Member.findOne as jest.Mock).mockResolvedValue(mockMemberRow(false));
+
+    const res = await request(buildApp()).get('/api/members');
+
+    const body = JSON.stringify(res.body).toLowerCase();
+    expect(body).not.toContain('email');
+    expect(body).not.toContain('phone');
+    expect(body).not.toContain('whatsapp');
+  });
+
+  it('rejects a non-numeric page query with 400', async () => {
+    jest.spyOn(User, 'findAndCountAll').mockResolvedValue({ count: 0, rows: [] } as never);
+
+    const res = await request(buildApp()).get('/api/members?page=abc');
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/members/member/:id (public detail)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('does not leak the owner email even when the model association is joined', async () => {
+    (Member.findByPk as jest.Mock).mockImplementation((id: string, options?: { include?: unknown }) => {
+      if (id !== MEMBER_ID) return Promise.resolve(null);
+      return Promise.resolve(mockMemberRow(Boolean(options?.include)));
+    });
+
+    const res = await request(buildApp()).get(`/api/members/member/${MEMBER_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = JSON.stringify(res.body).toLowerCase();
+    expect(body).not.toContain('email');
+    expect(body).not.toContain('phone');
+    expect(body).not.toContain('whatsapp');
+  });
+
+  it('still returns the safe profile fields (bio, education, skills, contacts)', async () => {
+    (Member.findByPk as jest.Mock).mockResolvedValue(mockMemberRow(false));
+
+    const res = await request(buildApp()).get(`/api/members/member/${MEMBER_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.member).toMatchObject({
+      name: 'Jane Doe',
+      bio: 'Loves distributed systems.',
+      skills: ['Node.js', 'Postgres'],
+    });
+    expect(res.body.data.member.education).toBeDefined();
+    expect(res.body.data.member.contacts).toBeDefined();
+  });
+
+  it('returns 404 for a non-existent member id', async () => {
+    (Member.findByPk as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(buildApp()).get(`/api/members/member/${MEMBER_ID}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a non-uuid id with 400', async () => {
+    const res = await request(buildApp()).get('/api/members/member/not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/members/:userId (public lookup by userId)', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('does not leak email, phone, or whatsapp', async () => {
+    (Member.findOne as jest.Mock).mockResolvedValue(mockMemberRow(false));
+
+    const res = await request(buildApp()).get(`/api/members/${USER_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = JSON.stringify(res.body).toLowerCase();
+    expect(body).not.toContain('email');
+    expect(body).not.toContain('phone');
+    expect(body).not.toContain('whatsapp');
+  });
+
+  it('rejects a non-uuid userId with 400', async () => {
+    const res = await request(buildApp()).get('/api/members/not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -3,6 +3,45 @@ import Member from '../models/member.model';
 import User from '../models/user.model';
 import cloudinary from "../utils/cloudinary.utils";
 
+// Explicit allow-list for public/unauthenticated member responses.
+// Email, phone, and WhatsApp must NEVER appear here, even if such a field is
+// added to the Member model later - add new safe fields individually, don't spread.
+// TODO: the frontend also wants "languages", a CV/resume URL, and this profile
+// doesn't have a dedicated tagline/availability field - none of these exist on
+// the Member model today. Needs a product decision + migration before they can
+// be added; do not guess at a schema for them here.
+function toPublicMemberProfile(member: Member) {
+  const {
+    id,
+    userId,
+    name,
+    role,
+    imageUrl,
+    bio,
+    education,
+    contacts,
+    skillDetails,
+    skills,
+    createdAt,
+    updatedAt,
+  } = member;
+
+  return {
+    id,
+    userId,
+    name,
+    role,
+    imageUrl,
+    bio,
+    education,
+    contacts,
+    skillDetails,
+    skills,
+    createdAt,
+    updatedAt,
+  };
+}
+
 // Get all members (public) - simplified for card display
 export const getAllMembers = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -69,17 +108,12 @@ export const getAllMembers = async (req: Request, res: Response): Promise<void> 
   }
 };
 
-// Get member by member table PK (id)
+// Get member by member table PK (id) - public, safe fields only
 export const getMemberById = async (req: Request, res: Response): Promise<void> => {
   try {
     const { id } = req.params;
 
-    const member = await Member.findByPk(id, {
-      include: [{
-        model: User,
-        attributes: ['email']
-      }]
-    });
+    const member = await Member.findByPk(id);
 
     if (!member) {
       res.status(404).json({
@@ -92,10 +126,7 @@ export const getMemberById = async (req: Request, res: Response): Promise<void> 
     res.status(200).json({
       status: 'success',
       data: {
-        member: {
-          ...member.toJSON(),
-          userId: member.userId
-        }
+        member: toPublicMemberProfile(member),
       },
     });
   } catch (error) {
@@ -107,7 +138,7 @@ export const getMemberById = async (req: Request, res: Response): Promise<void> 
   }
 };
 
-// Get member by userId param (public)
+// Get member by userId param (public) - safe fields only
 export const getMemberInfo = async (req: Request, res: Response): Promise<void> => {
   try {
     const { userId } = req.params;
@@ -125,7 +156,7 @@ export const getMemberInfo = async (req: Request, res: Response): Promise<void> 
     }
     res.status(200).json({
       status: 'success',
-      data: { member: { ...member.toJSON(), userId: member.userId } }
+      data: { member: toPublicMemberProfile(member) }
     });
   } catch (error) {
     console.error('Error fetching member information:', error);

--- a/src/routes/member.route.ts
+++ b/src/routes/member.route.ts
@@ -2,6 +2,11 @@ import express from 'express';
 import multer from 'multer';
 import { protectRoute, restrictTo } from '../middlewares/auth.middleware';
 import * as memberController from '../controllers/member.controller';
+import {
+  validateMemberIdParam,
+  validateUserIdParam,
+  validatePaginationQuery,
+} from '../validations/member.validation';
 
 const router = express.Router();
 
@@ -25,11 +30,11 @@ const upload = multer({
 });
 
 // Public routes
-router.get('/', memberController.getAllMembers);
-router.get('/member/:id', memberController.getMemberById);
+router.get('/', validatePaginationQuery, memberController.getAllMembers);
+router.get('/member/:id', validateMemberIdParam, memberController.getMemberById);
 
-// Get member info by userId (public or protected as needed)
-router.get('/:userId', memberController.getMemberInfo);
+// Get member info by userId (public)
+router.get('/:userId', validateUserIdParam, memberController.getMemberInfo);
 
 // Protected member profile routes (userId as path param)
 router.post(

--- a/src/swagger.config.ts
+++ b/src/swagger.config.ts
@@ -82,6 +82,62 @@ const options = {
         bearerFormat: 'JWT'
       }
     },
+    schemas: {
+      Error: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', example: 'fail' },
+          message: { type: 'string', example: 'Something went wrong' }
+        }
+      },
+      PublicMemberProfile: {
+        type: 'object',
+        description: 'Safe, public projection of a member profile. Never includes email, phone, or WhatsApp.',
+        properties: {
+          id: { type: 'string', format: 'uuid' },
+          userId: { type: 'string', format: 'uuid' },
+          name: { type: 'string' },
+          role: { type: 'string' },
+          imageUrl: { type: 'string', format: 'uri' },
+          bio: { type: 'string' },
+          education: {
+            type: 'object',
+            nullable: true,
+            properties: {
+              degree: { type: 'string' },
+              institution: { type: 'string' },
+              description: { type: 'string' },
+              imageUrl: { type: 'string', format: 'uri' }
+            }
+          },
+          contacts: {
+            type: 'object',
+            nullable: true,
+            description: 'Public social links only',
+            properties: {
+              linkedin: { type: 'string', format: 'uri' },
+              github: { type: 'string', format: 'uri' },
+              twitter: { type: 'string', format: 'uri' },
+              telegram: { type: 'string', format: 'uri' }
+            }
+          },
+          skillDetails: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                technologies: { type: 'array', items: { type: 'string' } },
+                percent: { type: 'number', example: 80 }
+              }
+            }
+          },
+          skills: { type: 'array', items: { type: 'string' } },
+          createdAt: { type: 'string', format: 'date-time' },
+          updatedAt: { type: 'string', format: 'date-time' }
+        }
+      }
+    },
   },
   paths: {
 '/health': {
@@ -2041,20 +2097,20 @@ delete: {
 "/api/members": {
   "get": {
     "summary": "Get all members",
-    "description": "Public endpoint - Retrieves all member information in card format",
+    "description": "Public endpoint - Retrieves all member information in card format. Never returns email, phone, or WhatsApp.",
     "tags": ["Members"],
     "security": [],
     "parameters": [
       {
         "in": "query",
         "name": "page",
-        "schema": { "type": "integer", "default": 1 },
+        "schema": { "type": "integer", "default": 1, "minimum": 1 },
         "description": "Page number"
       },
       {
         "in": "query",
         "name": "limit",
-        "schema": { "type": "integer", "default": 12 },
+        "schema": { "type": "integer", "default": 12, "minimum": 1, "maximum": 100 },
         "description": "Number of members per page"
       }
     ],
@@ -2094,6 +2150,14 @@ delete: {
           }
         }
       },
+      "400": {
+        "description": "Invalid page or limit query parameter",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
       "500": {
         "description": "Server error",
         "content": {
@@ -2114,7 +2178,7 @@ delete: {
 "/api/members/{userId}": {
   "get": {
     "summary": "Get member by userId",
-    "description": "Retrieves member information by userId (public)",
+    "description": "Public endpoint - Retrieves the full safe member profile (bio, education, skills, public social links) by userId. Never returns email, phone, or WhatsApp.",
     "tags": ["Members"],
     "security": [],
     "parameters": [
@@ -2122,7 +2186,7 @@ delete: {
         "in": "path",
         "name": "userId",
         "required": true,
-        "schema": { "type": "string" },
+        "schema": { "type": "string", "format": "uuid" },
         "description": "User ID to retrieve profile for"
       }
     ],
@@ -2138,11 +2202,19 @@ delete: {
                 "data": {
                   "type": "object",
                   "properties": {
-                    "member": { "$ref": "#/components/schemas/Member" }
+                    "member": { "$ref": "#/components/schemas/PublicMemberProfile" }
                   }
                 }
               }
             }
+          }
+        }
+      },
+      "400": {
+        "description": "userId is not a valid UUID",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
           }
         }
       },
@@ -2414,7 +2486,7 @@ delete: {
 "/api/members/member/{id}": {
   "get": {
     "summary": "Get member by ID",
-    "description": "Public endpoint - Retrieves member information by ID",
+    "description": "Public endpoint - Retrieves the full safe member profile by Member ID. Never returns email, phone, or WhatsApp.",
     "tags": ["Members"],
     "security": [],
     "parameters": [
@@ -2438,11 +2510,19 @@ delete: {
                 "data": {
                   "type": "object",
                   "properties": {
-                    "member": { "$ref": "#/components/schemas/Member" }
+                    "member": { "$ref": "#/components/schemas/PublicMemberProfile" }
                   }
                 }
               }
             }
+          }
+        }
+      },
+      "400": {
+        "description": "id is not a valid UUID",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
           }
         }
       },

--- a/src/validations/member.validation.ts
+++ b/src/validations/member.validation.ts
@@ -1,0 +1,66 @@
+import Joi from 'joi'
+import { NextFunction, Request, Response } from 'express'
+
+const idParamSchema = Joi.object({
+  id: Joi.string().guid({ version: ['uuidv4'] }).required().messages({
+    'string.guid': 'Member id must be a valid UUID',
+    'any.required': 'Member id is required',
+  }),
+})
+
+const userIdParamSchema = Joi.object({
+  userId: Joi.string().guid({ version: ['uuidv4'] }).required().messages({
+    'string.guid': 'userId must be a valid UUID',
+    'any.required': 'userId is required',
+  }),
+})
+
+const paginationQuerySchema = Joi.object({
+  page: Joi.number().integer().min(1).optional().messages({
+    'number.base': 'page must be a positive integer',
+    'number.integer': 'page must be a positive integer',
+    'number.min': 'page must be a positive integer',
+  }),
+  limit: Joi.number().integer().min(1).max(100).optional().messages({
+    'number.base': 'limit must be a positive integer between 1 and 100',
+    'number.integer': 'limit must be a positive integer between 1 and 100',
+    'number.min': 'limit must be a positive integer between 1 and 100',
+    'number.max': 'limit must be a positive integer between 1 and 100',
+  }),
+}).unknown(true)
+
+export const validateMemberIdParam = (req: Request, res: Response, next: NextFunction): void => {
+  const { error } = idParamSchema.validate(req.params, { abortEarly: false })
+  if (error) {
+    res.status(400).json({
+      status: 'fail',
+      message: error.details.map((detail) => detail.message).join(', '),
+    })
+    return
+  }
+  next()
+}
+
+export const validateUserIdParam = (req: Request, res: Response, next: NextFunction): void => {
+  const { error } = userIdParamSchema.validate(req.params, { abortEarly: false })
+  if (error) {
+    res.status(400).json({
+      status: 'fail',
+      message: error.details.map((detail) => detail.message).join(', '),
+    })
+    return
+  }
+  next()
+}
+
+export const validatePaginationQuery = (req: Request, res: Response, next: NextFunction): void => {
+  const { error } = paginationQuerySchema.validate(req.query, { abortEarly: false })
+  if (error) {
+    res.status(400).json({
+      status: 'fail',
+      message: error.details.map((detail) => detail.message).join(', '),
+    })
+    return
+  }
+  next()
+}


### PR DESCRIPTION
GET /api/members and GET /api/members/member/:id and GET /api/members/:userId were already unauthenticated, but getMemberById joined the User model with `attributes: ['email']` and spread it straight into the public response - leaking the member's email on a public endpoint.

Introduce an explicit allow-list projection (toPublicMemberProfile) used by all three public member reads, drop the User include, and add Joi validation for the :id/:userId params (must be UUID) and page/limit pagination query params.

No phone, WhatsApp, CV/resume URL, or languages fields exist on the Member model today; the projection omits them with a TODO rather than inventing a schema for them. skillDetails[].percent already existed and is included as-is.

Updated Swagger docs for the three routes and added a PublicMemberProfile/Error component schema (previously referenced via $ref throughout swagger.config.ts but never defined).