### PR TITLE
Add languages, cvUrl, tagline, availability fields to Member profile

### DIFF
--- a/__tests__/member.profile-fields.test.ts
+++ b/__tests__/member.profile-fields.test.ts
@@ -1,0 +1,157 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import jwt from 'jsonwebtoken';
+import memberRoutes from '../src/routes/member.route';
+import Member from '../src/models/member.model';
+import cloudinary from '../src/utils/cloudinary.utils';
+
+// Only Member is module-mocked; User is left real (see member.public.test.ts
+// for why: Member.belongsTo(User, ...) needs a genuine Model subclass).
+jest.mock('../src/models/member.model');
+jest.mock('../src/utils/cloudinary.utils', () => ({
+  uploader: {
+    upload: jest.fn(),
+    destroy: jest.fn(),
+  },
+}));
+
+const USER_ID = 'e5555555-5555-4555-8555-555555555555';
+const MEMBER_ID = 'f6666666-6666-4666-8666-666666666666';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/members', memberRoutes);
+  return app;
+}
+
+function authToken(): string {
+  return jwt.sign({ id: USER_ID, role: 'Member' }, process.env.JWT_SECRET as string, { expiresIn: '1h' });
+}
+
+function mockMemberInstance(overrides: Partial<Record<string, unknown>> = {}) {
+  const fields: Record<string, unknown> = {
+    id: MEMBER_ID,
+    userId: USER_ID,
+    name: 'Jane Doe',
+    role: 'Backend Developer',
+    imageUrl: '/members-images/member-demo.jpg',
+    bio: '',
+    skills: [],
+    ...overrides,
+  };
+  const instance: any = {
+    ...fields,
+    toJSON: () => fields,
+  };
+  instance.update = jest.fn().mockImplementation(async (data: Record<string, unknown>) => {
+    Object.assign(fields, data);
+    Object.assign(instance, data);
+    return instance;
+  });
+  return instance;
+}
+
+describe('Public member profile - new field defaults', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('defaults languages/cvUrl/tagline/availability for a member row that never set them', async () => {
+    (Member.findByPk as jest.Mock).mockResolvedValue(mockMemberInstance());
+
+    const res = await request(buildApp()).get(`/api/members/member/${MEMBER_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.member.languages).toEqual([]);
+    expect(res.body.data.member.cvUrl).toBeNull();
+    expect(res.body.data.member.tagline).toBeNull();
+    expect(res.body.data.member.availability).toBe(true);
+  });
+
+  it('returns the actual values once a member has set them', async () => {
+    (Member.findByPk as jest.Mock).mockResolvedValue(
+      mockMemberInstance({
+        languages: [{ name: 'English', level: 'Fluent' }],
+        cvUrl: 'https://res.cloudinary.com/demo/raw/upload/cv.pdf',
+        tagline: 'Backend dev who loves distributed systems',
+        availability: false,
+      })
+    );
+
+    const res = await request(buildApp()).get(`/api/members/member/${MEMBER_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.member.languages).toEqual([{ name: 'English', level: 'Fluent' }]);
+    expect(res.body.data.member.cvUrl).toBe('https://res.cloudinary.com/demo/raw/upload/cv.pdf');
+    expect(res.body.data.member.tagline).toBe('Backend dev who loves distributed systems');
+    expect(res.body.data.member.availability).toBe(false);
+  });
+});
+
+describe('PATCH /api/members/:userId - new field validation and persistence', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('rejects a tagline longer than 160 characters with 400', async () => {
+    (Member.findOne as jest.Mock).mockResolvedValue(mockMemberInstance());
+
+    const res = await request(buildApp())
+      .patch(`/api/members/${USER_ID}`)
+      .set('Authorization', `Bearer ${authToken()}`)
+      .field('tagline', 'x'.repeat(161));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid language level with 400', async () => {
+    (Member.findOne as jest.Mock).mockResolvedValue(mockMemberInstance());
+
+    const res = await request(buildApp())
+      .patch(`/api/members/${USER_ID}`)
+      .set('Authorization', `Bearer ${authToken()}`)
+      .field('languages', JSON.stringify([{ name: 'French', level: 'Expert' }]));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('persists tagline, availability, and languages on a valid update', async () => {
+    const member = mockMemberInstance();
+    (Member.findOne as jest.Mock).mockResolvedValue(member);
+
+    const res = await request(buildApp())
+      .patch(`/api/members/${USER_ID}`)
+      .set('Authorization', `Bearer ${authToken()}`)
+      .field('tagline', 'Loves shipping things')
+      .field('availability', 'false')
+      .field('languages', JSON.stringify([{ name: 'English', level: 'Native' }]));
+
+    expect(res.status).toBe(200);
+    expect(member.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tagline: 'Loves shipping things',
+        availability: false,
+        languages: [{ name: 'English', level: 'Native' }],
+      })
+    );
+  });
+
+  it('uploads a CV file to Cloudinary as a raw resource and persists cvUrl', async () => {
+    const member = mockMemberInstance();
+    (Member.findOne as jest.Mock).mockResolvedValue(member);
+    (cloudinary.uploader.upload as jest.Mock).mockResolvedValue({
+      secure_url: 'https://res.cloudinary.com/demo/raw/upload/jane-cv.pdf',
+    });
+
+    const res = await request(buildApp())
+      .patch(`/api/members/${USER_ID}`)
+      .set('Authorization', `Bearer ${authToken()}`)
+      .attach('cv', Buffer.from('%PDF-1.4 fake pdf content'), 'resume.pdf');
+
+    expect(res.status).toBe(200);
+    expect(cloudinary.uploader.upload).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ folder: 'innovation-hub/members/cv', resource_type: 'raw' })
+    );
+    expect(member.update).toHaveBeenCalledWith(
+      expect.objectContaining({ cvUrl: 'https://res.cloudinary.com/demo/raw/upload/jane-cv.pdf' })
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "ts-node src/index.ts",
     "test": "jest",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "db:sync-member": "ts-node src/scripts/sync-member-model.ts",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "prepare": "husky install",

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import fs from 'fs';
 import Member from '../models/member.model';
 import User from '../models/user.model';
 import cloudinary from "../utils/cloudinary.utils";
@@ -6,10 +7,9 @@ import cloudinary from "../utils/cloudinary.utils";
 // Explicit allow-list for public/unauthenticated member responses.
 // Email, phone, and WhatsApp must NEVER appear here, even if such a field is
 // added to the Member model later - add new safe fields individually, don't spread.
-// TODO: the frontend also wants "languages", a CV/resume URL, and this profile
-// doesn't have a dedicated tagline/availability field - none of these exist on
-// the Member model today. Needs a product decision + migration before they can
-// be added; do not guess at a schema for them here.
+// languages/cvUrl/tagline/availability may be NULL on rows created before these
+// columns existed (no backfill was run), so default them here rather than
+// trusting the DB defaultValue, which only applies to new inserts.
 function toPublicMemberProfile(member: Member) {
   const {
     id,
@@ -22,6 +22,10 @@ function toPublicMemberProfile(member: Member) {
     contacts,
     skillDetails,
     skills,
+    languages,
+    cvUrl,
+    tagline,
+    availability,
     createdAt,
     updatedAt,
   } = member;
@@ -37,6 +41,10 @@ function toPublicMemberProfile(member: Member) {
     contacts,
     skillDetails,
     skills,
+    languages: languages ?? [],
+    cvUrl: cvUrl ?? null,
+    tagline: tagline ?? null,
+    availability: availability ?? true,
     createdAt,
     updatedAt,
   };
@@ -180,21 +188,45 @@ export const createOrUpdateMember = async (req: Request, res: Response): Promise
     if ('name' in req.body) updateData.name = req.body.name;
     if ('role' in req.body) updateData.role = req.body.role;
     if ('bio' in req.body) updateData.bio = req.body.bio;
+    // tagline/availability/languages arrive already validated and normalized
+    // by validateMemberUpdateBody (JSON-parsed languages, coerced boolean).
+    if ('tagline' in req.body) updateData.tagline = req.body.tagline;
+    if ('availability' in req.body) updateData.availability = req.body.availability;
+    if ('languages' in req.body) updateData.languages = req.body.languages;
 
     let member = await Member.findOne({ where: { userId } });
 
-    if (req.file) {
+    const files = req.files as { [fieldname: string]: Express.Multer.File[] } | undefined;
+    const imageFile = files?.image?.[0];
+    const cvFile = files?.cv?.[0];
+
+    if (imageFile) {
       if (member?.imageUrl && !member.imageUrl.includes('member-demo.jpg')) {
         const publicId = member.imageUrl.split('/').pop()?.split('.')[0];
         if (publicId) {
           await cloudinary.uploader.destroy(`innovation-hub/members/${publicId}`);
         }
       }
-      const result = await cloudinary.uploader.upload(req.file.path, {
+      const result = await cloudinary.uploader.upload(imageFile.path, {
         folder: 'innovation-hub/members',
         resource_type: 'auto',
       });
       updateData.imageUrl = result.secure_url;
+    }
+
+    if (cvFile) {
+      if (member?.cvUrl) {
+        const publicId = member.cvUrl.split('/').pop()?.split('.')[0];
+        if (publicId) {
+          await cloudinary.uploader.destroy(`innovation-hub/members/cv/${publicId}`, { resource_type: 'raw' });
+        }
+      }
+      const result = await cloudinary.uploader.upload(cvFile.path, {
+        folder: 'innovation-hub/members/cv',
+        resource_type: 'raw',
+      });
+      updateData.cvUrl = result.secure_url;
+      fs.unlinkSync(cvFile.path);
     }
 
     if (member) {
@@ -228,6 +260,10 @@ export const createOrUpdateMember = async (req: Request, res: Response): Promise
         bio: req.body.bio || '',
         imageUrl: updateData.imageUrl || '/members-images/member-demo.jpg',
         skills: [],
+        languages: updateData.languages || [],
+        cvUrl: updateData.cvUrl || null,
+        tagline: updateData.tagline ?? null,
+        availability: 'availability' in updateData ? updateData.availability : true,
         createdAt: new Date(),
         updatedAt: new Date(),
       });

--- a/src/models/member.model.ts
+++ b/src/models/member.model.ts
@@ -25,6 +25,12 @@ interface Skill {
   percent: number;
 }
 
+// Define language interface
+interface Language {
+  name: string;
+  level: 'Native' | 'Fluent' | 'Intermediate' | 'Basic';
+}
+
 // Define member attributes
 interface MemberAttributes {
   id: string;
@@ -37,11 +43,18 @@ interface MemberAttributes {
   contacts?: Contacts;
   skillDetails?: Skill[];
   skills: string[];
+  languages?: Language[];
+  cvUrl?: string | null;
+  tagline?: string | null;
+  availability: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
 
-type MemberCreationAttributes = Optional<MemberAttributes, 'id' | 'education' | 'contacts' | 'skillDetails' | 'bio'>;
+type MemberCreationAttributes = Optional<
+  MemberAttributes,
+  'id' | 'education' | 'contacts' | 'skillDetails' | 'bio' | 'languages' | 'cvUrl' | 'tagline' | 'availability'
+>;
 
 class Member extends Model<MemberAttributes, MemberCreationAttributes> implements MemberAttributes {
   declare id: string;
@@ -54,6 +67,10 @@ class Member extends Model<MemberAttributes, MemberCreationAttributes> implement
   declare contacts: Contacts;
   declare skillDetails: Skill[];
   declare skills: string[];
+  declare languages: Language[];
+  declare cvUrl: string | null;
+  declare tagline: string | null;
+  declare availability: boolean;
   declare createdAt: Date;
   declare updatedAt: Date;
 }
@@ -105,6 +122,26 @@ Member.init(
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
       defaultValue: [],
+    },
+    languages: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: [],
+    },
+    cvUrl: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    tagline: {
+      type: DataTypes.STRING(160),
+      allowNull: true,
+      defaultValue: null,
+    },
+    availability: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
     createdAt: {
       allowNull: false,

--- a/src/routes/member.route.ts
+++ b/src/routes/member.route.ts
@@ -6,6 +6,7 @@ import {
   validateMemberIdParam,
   validateUserIdParam,
   validatePaginationQuery,
+  validateMemberUpdateBody,
 } from '../validations/member.validation';
 
 const router = express.Router();
@@ -17,13 +18,20 @@ const storage = multer.diskStorage({
     cb(null, file.fieldname + '-' + uniqueSuffix + '.' + file.originalname.split('.').pop());
   }
 });
+// image/educationImage fields accept images; cv accepts PDF/Word documents
 const fileFilter = (req: any, file: any, cb: any) => {
-  if (!file.originalname.match(/\.(jpg|jpeg|png|gif)$/)) {
+  if (file.fieldname === 'cv') {
+    if (!file.originalname.match(/\.(pdf|doc|docx)$/i)) {
+      return cb(new Error('CV must be a PDF or Word document!'), false);
+    }
+    return cb(null, true);
+  }
+  if (!file.originalname.match(/\.(jpg|jpeg|png|gif)$/i)) {
     return cb(new Error('Only image files are allowed!'), false);
   }
   cb(null, true);
 };
-const upload = multer({ 
+const upload = multer({
   storage: storage,
   fileFilter: fileFilter,
   limits: { fileSize: 5 * 1024 * 1024 } // 5MB
@@ -37,22 +45,30 @@ router.get('/member/:id', validateMemberIdParam, memberController.getMemberById)
 router.get('/:userId', validateUserIdParam, memberController.getMemberInfo);
 
 // Protected member profile routes (userId as path param)
+const profileUpload = upload.fields([
+  { name: 'image', maxCount: 1 },
+  { name: 'cv', maxCount: 1 },
+]);
+
 router.post(
-  '/:userId', 
-  protectRoute, 
-  upload.single('image'),
+  '/:userId',
+  protectRoute,
+  profileUpload,
+  validateMemberUpdateBody,
   memberController.createOrUpdateMember
 );
 router.put(
-  '/:userId', 
-  protectRoute, 
-  upload.single('image'),
+  '/:userId',
+  protectRoute,
+  profileUpload,
+  validateMemberUpdateBody,
   memberController.createOrUpdateMember
 );
 router.patch(
-  '/:userId', 
-  protectRoute, 
-  upload.single('image'),
+  '/:userId',
+  protectRoute,
+  profileUpload,
+  validateMemberUpdateBody,
   memberController.createOrUpdateMember
 );
 

--- a/src/scripts/sync-member-model.ts
+++ b/src/scripts/sync-member-model.ts
@@ -1,0 +1,22 @@
+// One-off, scoped schema sync for the Member model - NOT a Sequelize CLI migration.
+// Run once against an environment that can reach the real database:
+//   npm run db:sync-member
+// Only alters the `members` table (adds languages/cvUrl/tagline/availability
+// columns); it never touches other tables.
+import sequelize from '../config/database';
+import Member from '../models/member.model';
+
+async function run(): Promise<void> {
+  try {
+    console.log('Syncing Member model schema (alter: true)...');
+    await Member.sync({ alter: true });
+    console.log('Member table schema is now in sync with the model.');
+  } catch (error) {
+    console.error('Failed to sync Member schema:', error);
+    process.exitCode = 1;
+  } finally {
+    await sequelize.close();
+  }
+}
+
+run();

--- a/src/swagger.config.ts
+++ b/src/swagger.config.ts
@@ -133,6 +133,19 @@ const options = {
             }
           },
           skills: { type: 'array', items: { type: 'string' } },
+          languages: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string', example: 'English' },
+                level: { type: 'string', enum: ['Native', 'Fluent', 'Intermediate', 'Basic'] }
+              }
+            }
+          },
+          cvUrl: { type: 'string', format: 'uri', nullable: true },
+          tagline: { type: 'string', nullable: true, maxLength: 160 },
+          availability: { type: 'boolean', default: true },
           createdAt: { type: 'string', format: 'date-time' },
           updatedAt: { type: 'string', format: 'date-time' }
         }
@@ -2252,7 +2265,11 @@ delete: {
               "name": { "type": "string" },
               "role": { "type": "string" },
               "bio": { "type": "string" },
-              "image": { "type": "string", "format": "binary" }
+              "tagline": { "type": "string", "maxLength": 160, "description": "Short profile tagline (max 160 characters)" },
+              "availability": { "type": "boolean", "description": "Whether the member is currently available" },
+              "languages": { "type": "string", "description": "JSON-encoded array of {name, level}, e.g. [{\"name\":\"English\",\"level\":\"Fluent\"}]. level must be one of Native, Fluent, Intermediate, Basic." },
+              "image": { "type": "string", "format": "binary", "description": "Profile image file" },
+              "cv": { "type": "string", "format": "binary", "description": "CV/resume file (PDF or Word document)" }
             }
           }
         }
@@ -2321,7 +2338,11 @@ delete: {
               "name": { "type": "string" },
               "role": { "type": "string" },
               "bio": { "type": "string" },
-              "image": { "type": "string", "format": "binary" }
+              "tagline": { "type": "string", "maxLength": 160, "description": "Short profile tagline (max 160 characters)" },
+              "availability": { "type": "boolean", "description": "Whether the member is currently available" },
+              "languages": { "type": "string", "description": "JSON-encoded array of {name, level}, e.g. [{\"name\":\"English\",\"level\":\"Fluent\"}]. level must be one of Native, Fluent, Intermediate, Basic." },
+              "image": { "type": "string", "format": "binary", "description": "Profile image file" },
+              "cv": { "type": "string", "format": "binary", "description": "CV/resume file (PDF or Word document)" }
             }
           }
         }
@@ -2389,7 +2410,11 @@ delete: {
               "name": { "type": "string" },
               "role": { "type": "string" },
               "bio": { "type": "string" },
-              "image": { "type": "string", "format": "binary" }
+              "tagline": { "type": "string", "maxLength": 160, "description": "Short profile tagline (max 160 characters)" },
+              "availability": { "type": "boolean", "description": "Whether the member is currently available" },
+              "languages": { "type": "string", "description": "JSON-encoded array of {name, level}, e.g. [{\"name\":\"English\",\"level\":\"Fluent\"}]. level must be one of Native, Fluent, Intermediate, Basic." },
+              "image": { "type": "string", "format": "binary", "description": "Profile image file" },
+              "cv": { "type": "string", "format": "binary", "description": "CV/resume file (PDF or Word document)" }
             }
           }
         }

--- a/src/validations/member.validation.ts
+++ b/src/validations/member.validation.ts
@@ -15,6 +15,69 @@ const userIdParamSchema = Joi.object({
   }),
 })
 
+const LANGUAGE_LEVELS = ['Native', 'Fluent', 'Intermediate', 'Basic'] as const
+
+const languageSchema = Joi.object({
+  name: Joi.string().trim().min(1).required().messages({
+    'any.required': 'Each language entry requires a name',
+    'string.empty': 'Each language entry requires a name',
+  }),
+  level: Joi.string().valid(...LANGUAGE_LEVELS).required().messages({
+    'any.only': `level must be one of: ${LANGUAGE_LEVELS.join(', ')}`,
+    'any.required': 'Each language entry requires a level',
+  }),
+})
+
+const memberUpdateBodySchema = Joi.object({
+  name: Joi.string().optional(),
+  role: Joi.string().optional(),
+  bio: Joi.string().allow('').optional(),
+  tagline: Joi.string().trim().max(160).allow('', null).optional().messages({
+    'string.max': 'tagline must be at most 160 characters',
+  }),
+  availability: Joi.boolean().optional().messages({
+    'boolean.base': 'availability must be a boolean',
+  }),
+  languages: Joi.array().items(languageSchema).optional().messages({
+    'array.base': 'languages must be an array',
+  }),
+}).unknown(true)
+
+function parseLanguagesInput(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch {
+      return value
+    }
+  }
+  return value
+}
+
+export const validateMemberUpdateBody = (req: Request, res: Response, next: NextFunction): void => {
+  const candidate: Record<string, unknown> = { ...req.body }
+  if ('languages' in candidate) {
+    candidate.languages = parseLanguagesInput(candidate.languages)
+  }
+
+  const { error, value } = memberUpdateBodySchema.validate(candidate, { abortEarly: false })
+  if (error) {
+    res.status(400).json({
+      status: 'fail',
+      message: error.details.map((detail) => detail.message).join(', '),
+    })
+    return
+  }
+
+  // Write back normalized/coerced values (parsed languages, coerced availability boolean)
+  // so the controller can read req.body directly without re-parsing.
+  if ('languages' in value) req.body.languages = value.languages
+  if ('availability' in value) req.body.availability = value.availability
+  if ('tagline' in value) req.body.tagline = value.tagline
+
+  next()
+}
+
 const paginationQuerySchema = Joi.object({
   page: Joi.number().integer().min(1).optional().messages({
     'number.base': 'page must be a positive integer',


### PR DESCRIPTION
Adds four new columns to the Member model: languages (JSONB array of {name, level}), cvUrl (nullable string, set via a Cloudinary upload), tagline (nullable string, 160 char max), and availability (boolean, default true). Schema is applied via a scoped Member.sync({alter:true}) script (src/scripts/sync-member-model.ts, run with `npm run db:sync-member`) rather than a Sequelize CLI migration file, per instruction. This has not been executed against the real database from this environment - there is no network path to the configured Postgres instance from this sandbox, so the columns do not exist yet. Someone with DB access needs to run the script once before these fields will persist.

toPublicMemberProfile() now includes all four fields, defaulting languages to [], cvUrl/tagline to null, and availability to true for rows that predate these columns (existing rows will be NULL until the sync script runs and new rows are saved, so the projection does not rely solely on the Sequelize column default).

Extended the existing "update my profile" endpoint (POST/PUT/PATCH /api/members/:userId) to accept tagline, availability, and languages, plus a new cv file upload (mirroring the image upload pattern already used elsewhere: multer -> Cloudinary, but with resource_type: 'raw' since CVs are PDFs/Word docs, not images). Added Joi validation (tagline max length, availability boolean coercion, language level enum) via a new validateMemberUpdateBody middleware.

Tests cover: safe defaults on the public endpoint for a member that never set these fields, actual values once set, rejecting an overlong tagline and an invalid language level with 400, persisting a valid update, and the CV upload path (mocking Cloudinary). No stray files were left in uploads/ by the test run - the CV upload path deletes its local temp file after a successful Cloudinary upload, and the rejected-upload test cases never reach the point of writing one.