### PR TITLE
Replace telegram with instagram in member contacts

### DIFF
--- a/__tests__/member.contacts-instagram.test.ts
+++ b/__tests__/member.contacts-instagram.test.ts
@@ -1,0 +1,110 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import jwt from 'jsonwebtoken';
+import memberRoutes from '../src/routes/member.route';
+import Member from '../src/models/member.model';
+
+// Only Member is module-mocked; User is left real (Member.belongsTo(User, ...)
+// at import time needs a genuine Sequelize Model subclass - see member.public.test.ts).
+jest.mock('../src/models/member.model');
+jest.mock('../src/utils/cloudinary.utils', () => ({
+  uploader: { upload: jest.fn(), destroy: jest.fn() },
+}));
+
+const USER_ID = 'a7777777-7777-4777-8777-777777777777';
+const MEMBER_ID = 'b8888888-8888-4888-8888-888888888888';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/members', memberRoutes);
+  return app;
+}
+
+function authToken(): string {
+  return jwt.sign({ id: USER_ID, role: 'Member' }, process.env.JWT_SECRET as string, { expiresIn: '1h' });
+}
+
+function mockMemberInstance(overrides: Partial<Record<string, unknown>> = {}) {
+  const fields: Record<string, unknown> = {
+    id: MEMBER_ID,
+    userId: USER_ID,
+    name: 'Jane Doe',
+    role: 'Backend Developer',
+    imageUrl: '/members-images/member-demo.jpg',
+    bio: '',
+    skills: [],
+    ...overrides,
+  };
+  const instance: any = { ...fields, toJSON: () => fields };
+  instance.update = jest.fn().mockImplementation(async (data: Record<string, unknown>) => {
+    Object.assign(fields, data);
+    Object.assign(instance, data);
+    return instance;
+  });
+  return instance;
+}
+
+describe('PATCH /api/members/:userId/contacts - instagram replaces telegram', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('accepts and persists an instagram link', async () => {
+    const member = mockMemberInstance({ contacts: {} });
+    (Member.findOne as jest.Mock).mockResolvedValue(member);
+
+    const res = await request(buildApp())
+      .patch(`/api/members/${USER_ID}/contacts`)
+      .set('Authorization', `Bearer ${authToken()}`)
+      .send({ instagram: 'https://instagram.com/janedoe' });
+
+    expect(res.status).toBe(200);
+    expect(member.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contacts: expect.objectContaining({ instagram: 'https://instagram.com/janedoe' }),
+      })
+    );
+  });
+
+  it('ignores a telegram field instead of persisting it', async () => {
+    const member = mockMemberInstance({ contacts: {} });
+    (Member.findOne as jest.Mock).mockResolvedValue(member);
+
+    const res = await request(buildApp())
+      .patch(`/api/members/${USER_ID}/contacts`)
+      .set('Authorization', `Bearer ${authToken()}`)
+      .send({ telegram: 'https://t.me/janedoe' });
+
+    expect(res.status).toBe(200);
+    const [[persistedArgs]] = (member.update as jest.Mock).mock.calls;
+    expect(persistedArgs.contacts).not.toHaveProperty('telegram');
+    expect(persistedArgs.contacts).not.toHaveProperty('instagram');
+  });
+});
+
+describe('Public member profile contacts - never exposes telegram', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('exposes instagram when set', async () => {
+    (Member.findByPk as jest.Mock).mockResolvedValue(
+      mockMemberInstance({ contacts: { linkedin: 'https://linkedin.com/in/jane', instagram: 'https://instagram.com/jane' } })
+    );
+
+    const res = await request(buildApp()).get(`/api/members/member/${MEMBER_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.member.contacts.instagram).toBe('https://instagram.com/jane');
+  });
+
+  it('never exposes a legacy telegram value even if still present on the stored row', async () => {
+    (Member.findByPk as jest.Mock).mockResolvedValue(
+      mockMemberInstance({ contacts: { linkedin: 'https://linkedin.com/in/jane', telegram: 'https://t.me/legacy' } })
+    );
+
+    const res = await request(buildApp()).get(`/api/members/member/${MEMBER_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.member.contacts).not.toHaveProperty('telegram');
+    const body = JSON.stringify(res.body).toLowerCase();
+    expect(body).not.toContain('telegram');
+  });
+});

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -3,6 +3,18 @@ import Member from '../models/member.model';
 import User from '../models/user.model';
 import cloudinary from "../utils/cloudinary.utils";
 
+// Contacts are allow-listed too: instagram replaced telegram as the accepted
+// key, but old rows saved before this change may still hold a `telegram`
+// value in their JSONB blob (nothing was backfilled). Filtering here, rather
+// than passing `contacts` straight through, guarantees a legacy telegram
+// value is never surfaced by the public endpoints even though it isn't
+// deleted from storage.
+function toPublicContacts(contacts: Member['contacts']) {
+  if (!contacts) return contacts;
+  const { linkedin, github, twitter, instagram } = contacts;
+  return { linkedin, github, twitter, instagram };
+}
+
 // Explicit allow-list for public/unauthenticated member responses.
 // Email, phone, and WhatsApp must NEVER appear here, even if such a field is
 // added to the Member model later - add new safe fields individually, don't spread.
@@ -34,7 +46,7 @@ function toPublicMemberProfile(member: Member) {
     imageUrl,
     bio,
     education,
-    contacts,
+    contacts: toPublicContacts(contacts),
     skillDetails,
     skills,
     createdAt,
@@ -266,7 +278,7 @@ export const createOrUpdateContacts = async (req: Request, res: Response): Promi
     if ('linkedin' in req.body) contacts.linkedin = req.body.linkedin;
     if ('github' in req.body) contacts.github = req.body.github;
     if ('twitter' in req.body) contacts.twitter = req.body.twitter;
-    if ('telegram' in req.body) contacts.telegram = req.body.telegram;
+    if ('instagram' in req.body) contacts.instagram = req.body.instagram;
 
     if (member) {
       await member.update({

--- a/src/models/member.model.ts
+++ b/src/models/member.model.ts
@@ -15,7 +15,7 @@ interface Contacts {
   linkedin: string;
   github: string;
   twitter?: string;
-  telegram?: string;
+  instagram?: string;
 }
 
 // Define skill interface

--- a/src/swagger.config.ts
+++ b/src/swagger.config.ts
@@ -118,7 +118,7 @@ const options = {
               linkedin: { type: 'string', format: 'uri' },
               github: { type: 'string', format: 'uri' },
               twitter: { type: 'string', format: 'uri' },
-              telegram: { type: 'string', format: 'uri' }
+              instagram: { type: 'string', format: 'uri' }
             }
           },
           skillDetails: {
@@ -2561,7 +2561,7 @@ delete: {
               "linkedin": { "type": "string", "format": "uri" },
               "github": { "type": "string", "format": "uri" },
               "twitter": { "type": "string", "format": "uri" },
-              "telegram": { "type": "string", "format": "uri" }
+              "instagram": { "type": "string", "format": "uri" }
             }
           }
         }
@@ -2586,7 +2586,7 @@ delete: {
                         "linkedin": { "type": "string" },
                         "github": { "type": "string" },
                         "twitter": { "type": "string" },
-                        "telegram": { "type": "string" }
+                        "instagram": { "type": "string" }
                       }
                     },
                     "userId": { "type": "string" }
@@ -2615,7 +2615,7 @@ delete: {
                         "linkedin": { "type": "string" },
                         "github": { "type": "string" },
                         "twitter": { "type": "string" },
-                        "telegram": { "type": "string" }
+                        "instagram": { "type": "string" }
                       }
                     },
                     "userId": { "type": "string" }
@@ -2659,7 +2659,7 @@ delete: {
               "linkedin": { "type": "string", "format": "uri" },
               "github": { "type": "string", "format": "uri" },
               "twitter": { "type": "string", "format": "uri" },
-              "telegram": { "type": "string", "format": "uri" }
+              "instagram": { "type": "string", "format": "uri" }
             }
           }
         }
@@ -2684,7 +2684,7 @@ delete: {
                         "linkedin": { "type": "string" },
                         "github": { "type": "string" },
                         "twitter": { "type": "string" },
-                        "telegram": { "type": "string" }
+                        "instagram": { "type": "string" }
                       }
                     },
                     "userId": { "type": "string" }


### PR DESCRIPTION
The contacts field on Member is a single JSONB column, not individual DB columns, so this is a code/validation change only - no column add/drop, no migration. The key being replaced was exactly `telegram` (Contacts.telegram in member.model.ts).

Swap the Contacts interface field, the accepted key in createOrUpdateContacts (instagram is now read from the request body instead of telegram), and every telegram reference in swagger.config.ts.

The public member projection no longer passes the stored `contacts` object straight through - toPublicContacts() now allow-lists exactly {linkedin, github, twitter, instagram}. This guarantees a legacy telegram value on a row saved before this change (nothing was backfilled, since JSONB has no fixed schema and nothing is destroyed by this change) is never exposed by the public endpoints going forward, without needing to touch existing stored data.

Could not query the live database from this environment to check for real non-null telegram values (no network path to the configured Postgres instance, same as noted on the previous branch). No existing data is dropped by this change either way - old telegram values simply stop being written and stop being surfaced.

No test fixtures from the previously merged branches referenced telegram, so there was nothing to update there.